### PR TITLE
models

### DIFF
--- a/lib/college_tracker/extracurricular_activities.ex
+++ b/lib/college_tracker/extracurricular_activities.ex
@@ -1,0 +1,104 @@
+defmodule CollegeTracker.ExtracurricularActivities do
+  @moduledoc """
+  The ExtracurricularActivities context.
+  """
+
+  import Ecto.Query, warn: false
+
+  alias CollegeTracker.ExtracurricularActivities.ActivityCategory
+  alias CollegeTracker.Repo
+
+  @doc """
+  Returns the list of activity_categories.
+
+  ## Examples
+
+      iex> list_activity_categories()
+      [%ActivityCategory{}, ...]
+
+  """
+  def list_activity_categories do
+    Repo.all(ActivityCategory)
+  end
+
+  @doc """
+  Gets a single activity_category.
+
+  Raises `Ecto.NoResultsError` if the Activity category does not exist.
+
+  ## Examples
+
+      iex> get_activity_category!(123)
+      %ActivityCategory{}
+
+      iex> get_activity_category!(456)
+      ** (Ecto.NoResultsError)
+
+  """
+  def get_activity_category!(id), do: Repo.get!(ActivityCategory, id)
+
+  @doc """
+  Creates a activity_category.
+
+  ## Examples
+
+      iex> create_activity_category(%{field: value})
+      {:ok, %ActivityCategory{}}
+
+      iex> create_activity_category(%{field: bad_value})
+      {:error, %Ecto.Changeset{}}
+
+  """
+  def create_activity_category(attrs \\ %{}) do
+    %ActivityCategory{}
+    |> ActivityCategory.changeset(attrs)
+    |> Repo.insert()
+  end
+
+  @doc """
+  Updates a activity_category.
+
+  ## Examples
+
+      iex> update_activity_category(activity_category, %{field: new_value})
+      {:ok, %ActivityCategory{}}
+
+      iex> update_activity_category(activity_category, %{field: bad_value})
+      {:error, %Ecto.Changeset{}}
+
+  """
+  def update_activity_category(%ActivityCategory{} = activity_category, attrs) do
+    activity_category
+    |> ActivityCategory.changeset(attrs)
+    |> Repo.update()
+  end
+
+  @doc """
+  Deletes a activity_category.
+
+  ## Examples
+
+      iex> delete_activity_category(activity_category)
+      {:ok, %ActivityCategory{}}
+
+      iex> delete_activity_category(activity_category)
+      {:error, %Ecto.Changeset{}}
+
+  """
+  def delete_activity_category(%ActivityCategory{} = activity_category) do
+    Repo.delete(activity_category)
+  end
+
+  @doc """
+  Returns an `%Ecto.Changeset{}` for tracking activity_category changes.
+
+  ## Examples
+
+      iex> change_activity_category(activity_category)
+      %Ecto.Changeset{data: %ActivityCategory{}}
+
+  """
+  def change_activity_category(%ActivityCategory{} = activity_category, attrs \\ %{}) do
+    ActivityCategory.changeset(activity_category, attrs)
+  end
+end

--- a/lib/college_tracker/extracurricular_activities.ex
+++ b/lib/college_tracker/extracurricular_activities.ex
@@ -6,6 +6,7 @@ defmodule CollegeTracker.ExtracurricularActivities do
   import Ecto.Query, warn: false
 
   alias CollegeTracker.ExtracurricularActivities.ActivityCategory
+  alias CollegeTracker.ExtracurricularActivities.ActivityType
   alias CollegeTracker.Repo
 
   @doc """
@@ -100,5 +101,99 @@ defmodule CollegeTracker.ExtracurricularActivities do
   """
   def change_activity_category(%ActivityCategory{} = activity_category, attrs \\ %{}) do
     ActivityCategory.changeset(activity_category, attrs)
+  end
+
+  @doc """
+  Returns the list of activity_types.
+
+  ## Examples
+
+      iex> list_activity_types()
+      [%ActivityType{}, ...]
+
+  """
+  def list_activity_types do
+    Repo.all(ActivityType)
+  end
+
+  @doc """
+  Gets a single activity_type.
+
+  Raises `Ecto.NoResultsError` if the Activity type does not exist.
+
+  ## Examples
+
+      iex> get_activity_type!(123)
+      %ActivityType{}
+
+      iex> get_activity_type!(456)
+      ** (Ecto.NoResultsError)
+
+  """
+  def get_activity_type!(id), do: Repo.get!(ActivityType, id)
+
+  @doc """
+  Creates a activity_type.
+
+  ## Examples
+
+      iex> create_activity_type(%{field: value})
+      {:ok, %ActivityType{}}
+
+      iex> create_activity_type(%{field: bad_value})
+      {:error, %Ecto.Changeset{}}
+
+  """
+  def create_activity_type(attrs \\ %{}) do
+    %ActivityType{}
+    |> ActivityType.changeset(attrs)
+    |> Repo.insert()
+  end
+
+  @doc """
+  Updates a activity_type.
+
+  ## Examples
+
+      iex> update_activity_type(activity_type, %{field: new_value})
+      {:ok, %ActivityType{}}
+
+      iex> update_activity_type(activity_type, %{field: bad_value})
+      {:error, %Ecto.Changeset{}}
+
+  """
+  def update_activity_type(%ActivityType{} = activity_type, attrs) do
+    activity_type
+    |> ActivityType.changeset(attrs)
+    |> Repo.update()
+  end
+
+  @doc """
+  Deletes a activity_type.
+
+  ## Examples
+
+      iex> delete_activity_type(activity_type)
+      {:ok, %ActivityType{}}
+
+      iex> delete_activity_type(activity_type)
+      {:error, %Ecto.Changeset{}}
+
+  """
+  def delete_activity_type(%ActivityType{} = activity_type) do
+    Repo.delete(activity_type)
+  end
+
+  @doc """
+  Returns an `%Ecto.Changeset{}` for tracking activity_type changes.
+
+  ## Examples
+
+      iex> change_activity_type(activity_type)
+      %Ecto.Changeset{data: %ActivityType{}}
+
+  """
+  def change_activity_type(%ActivityType{} = activity_type, attrs \\ %{}) do
+    ActivityType.changeset(activity_type, attrs)
   end
 end

--- a/lib/college_tracker/extracurricular_activities.ex
+++ b/lib/college_tracker/extracurricular_activities.ex
@@ -5,6 +5,7 @@ defmodule CollegeTracker.ExtracurricularActivities do
 
   import Ecto.Query, warn: false
 
+  alias CollegeTracker.ExtracurricularActivities.Activity
   alias CollegeTracker.ExtracurricularActivities.ActivityCategory
   alias CollegeTracker.ExtracurricularActivities.ActivityType
   alias CollegeTracker.Repo
@@ -195,5 +196,99 @@ defmodule CollegeTracker.ExtracurricularActivities do
   """
   def change_activity_type(%ActivityType{} = activity_type, attrs \\ %{}) do
     ActivityType.changeset(activity_type, attrs)
+  end
+
+  @doc """
+  Returns the list of activities.
+
+  ## Examples
+
+      iex> list_activities()
+      [%Activity{}, ...]
+
+  """
+  def list_activities do
+    Repo.all(Activity)
+  end
+
+  @doc """
+  Gets a single activity.
+
+  Raises `Ecto.NoResultsError` if the Activity does not exist.
+
+  ## Examples
+
+      iex> get_activity!(123)
+      %Activity{}
+
+      iex> get_activity!(456)
+      ** (Ecto.NoResultsError)
+
+  """
+  def get_activity!(id), do: Repo.get!(Activity, id)
+
+  @doc """
+  Creates a activity.
+
+  ## Examples
+
+      iex> create_activity(%{field: value})
+      {:ok, %Activity{}}
+
+      iex> create_activity(%{field: bad_value})
+      {:error, %Ecto.Changeset{}}
+
+  """
+  def create_activity(attrs \\ %{}) do
+    %Activity{}
+    |> Activity.changeset(attrs)
+    |> Repo.insert()
+  end
+
+  @doc """
+  Updates a activity.
+
+  ## Examples
+
+      iex> update_activity(activity, %{field: new_value})
+      {:ok, %Activity{}}
+
+      iex> update_activity(activity, %{field: bad_value})
+      {:error, %Ecto.Changeset{}}
+
+  """
+  def update_activity(%Activity{} = activity, attrs) do
+    activity
+    |> Activity.changeset(attrs)
+    |> Repo.update()
+  end
+
+  @doc """
+  Deletes a activity.
+
+  ## Examples
+
+      iex> delete_activity(activity)
+      {:ok, %Activity{}}
+
+      iex> delete_activity(activity)
+      {:error, %Ecto.Changeset{}}
+
+  """
+  def delete_activity(%Activity{} = activity) do
+    Repo.delete(activity)
+  end
+
+  @doc """
+  Returns an `%Ecto.Changeset{}` for tracking activity changes.
+
+  ## Examples
+
+      iex> change_activity(activity)
+      %Ecto.Changeset{data: %Activity{}}
+
+  """
+  def change_activity(%Activity{} = activity, attrs \\ %{}) do
+    Activity.changeset(activity, attrs)
   end
 end

--- a/lib/college_tracker/extracurricular_activities/activity.ex
+++ b/lib/college_tracker/extracurricular_activities/activity.ex
@@ -1,0 +1,72 @@
+defmodule CollegeTracker.ExtracurricularActivities.Activity do
+  @moduledoc """
+  Schema for Activity in the ExtracurricularActivities context.
+
+  An `Activity` represents an extracurricular task undertaken by a student. Each
+  activity records the following:
+
+  - `name`: The title or short description of the activity.
+  - `description`: More detailed information about what the activity entailed.
+  - `status`: The current stage of the activity in the approval process.
+      The status can be one of the following:
+        - `:draft`: The activity is not yet submitted.
+        - `:submitted`: The activity has been submitted for approval.
+        - `:approved`: The activity has been approved.
+        - `:rejected`: The activity was not approved.
+  - `hours`: The total time spent on the activity.
+  - `activity_type_id`: Reference to the type of the activity.
+  - `start_date`: (Optional) The date when the activity started.
+  - `end_date`: (Optional) The date when the activity ended.
+  - `submission_date`: (Optional) The date when the activity was submitted for approval.
+  - `certificate`: (Optional) A path to a file, like a PDF, proving the activity took place.
+  """
+
+  use Ecto.Schema
+  import Ecto.Changeset
+
+  alias CollegeTracker.ExtracurricularActivities.ActivityType
+
+  @primary_key {:id, :binary_id, autogenerate: true}
+  @foreign_key_type :binary_id
+
+  @required_fields ~w(name status hours activity_type_id)a
+  @optional_fields ~w(description start_date end_date submission_date certificate)a
+
+  @type t :: %__MODULE__{
+          id: binary(),
+          certificate: String.t() | nil,
+          description: String.t() | nil,
+          end_date: Date.t() | nil,
+          hours: non_neg_integer(),
+          name: String.t(),
+          start_date: Date.t() | nil,
+          status: :draft | :submitted | :approved | :rejected,
+          submission_date: Date.t() | nil,
+          activity_type_id: binary(),
+          activity_type: ActivityType.t() | Ecto.Association.NotLoaded.t(),
+          inserted_at: DateTime.t(),
+          updated_at: DateTime.t()
+        }
+
+  schema "activities" do
+    field :certificate, :string
+    field :description, :string
+    field :end_date, :date
+    field :hours, :integer
+    field :name, :string
+    field :start_date, :date
+    field :status, Ecto.Enum, values: [:draft, :submitted, :approved, :rejected], default: :draft
+    field :submission_date, :date
+
+    belongs_to :activity_type, ActivityType
+
+    timestamps()
+  end
+
+  def changeset(activity, attrs) do
+    activity
+    |> cast(attrs, @required_fields ++ @optional_fields)
+    |> validate_required(@required_fields)
+    |> assoc_constraint(:activity_type)
+  end
+end

--- a/lib/college_tracker/extracurricular_activities/activity_category.ex
+++ b/lib/college_tracker/extracurricular_activities/activity_category.ex
@@ -2,7 +2,7 @@ defmodule CollegeTracker.ExtracurricularActivities.ActivityCategory do
   @moduledoc """
   The ActivityCategory schema is used for representing a category of
   extracurricular activities in the CollegeTracker application. Each category
-  has a name and a limit of hours that can be attributed to it.
+  has a name, total_limit, remaining_limit and status.
   """
 
   use Ecto.Schema
@@ -17,14 +17,18 @@ defmodule CollegeTracker.ExtracurricularActivities.ActivityCategory do
   @type t :: %__MODULE__{
           id: binary,
           name: String.t(),
-          limit: integer,
+          total_limit: integer,
+          remaining_limit: integer,
+          status: atom,
           inserted_at: DateTime.t(),
           updated_at: DateTime.t()
         }
 
   schema "activity_categories" do
-    field :limit, :integer
     field :name, :string
+    field :total_limit, :integer
+    field :remaining_limit, :integer
+    field :status, Ecto.Enum, values: [:available, :complete]
 
     has_many :activity_types, ActivityType
 
@@ -34,7 +38,7 @@ defmodule CollegeTracker.ExtracurricularActivities.ActivityCategory do
   @doc false
   def changeset(activity_category, attrs) do
     activity_category
-    |> cast(attrs, [:name, :limit])
-    |> validate_required([:name, :limit])
+    |> cast(attrs, [:name, :total_limit, :remaining_limit, :status])
+    |> validate_required([:name, :total_limit, :remaining_limit, :status])
   end
 end

--- a/lib/college_tracker/extracurricular_activities/activity_category.ex
+++ b/lib/college_tracker/extracurricular_activities/activity_category.ex
@@ -6,7 +6,10 @@ defmodule CollegeTracker.ExtracurricularActivities.ActivityCategory do
   """
 
   use Ecto.Schema
+
   import Ecto.Changeset
+
+  alias CollegeTracker.ExtracurricularActivities.ActivityType
 
   @primary_key {:id, :binary_id, autogenerate: true}
   @foreign_key_type :binary_id
@@ -22,6 +25,8 @@ defmodule CollegeTracker.ExtracurricularActivities.ActivityCategory do
   schema "activity_categories" do
     field :limit, :integer
     field :name, :string
+
+    has_many :activity_types, ActivityType
 
     timestamps()
   end

--- a/lib/college_tracker/extracurricular_activities/activity_category.ex
+++ b/lib/college_tracker/extracurricular_activities/activity_category.ex
@@ -1,0 +1,35 @@
+defmodule CollegeTracker.ExtracurricularActivities.ActivityCategory do
+  @moduledoc """
+  The ActivityCategory schema is used for representing a category of
+  extracurricular activities in the CollegeTracker application. Each category
+  has a name and a limit of hours that can be attributed to it.
+  """
+
+  use Ecto.Schema
+  import Ecto.Changeset
+
+  @primary_key {:id, :binary_id, autogenerate: true}
+  @foreign_key_type :binary_id
+
+  @type t :: %__MODULE__{
+          id: binary,
+          name: String.t(),
+          limit: integer,
+          inserted_at: DateTime.t(),
+          updated_at: DateTime.t()
+        }
+
+  schema "activity_categories" do
+    field :limit, :integer
+    field :name, :string
+
+    timestamps()
+  end
+
+  @doc false
+  def changeset(activity_category, attrs) do
+    activity_category
+    |> cast(attrs, [:name, :limit])
+    |> validate_required([:name, :limit])
+  end
+end

--- a/lib/college_tracker/extracurricular_activities/activity_type.ex
+++ b/lib/college_tracker/extracurricular_activities/activity_type.ex
@@ -35,6 +35,7 @@ defmodule CollegeTracker.ExtracurricularActivities.ActivityType do
 
   import Ecto.Changeset
 
+  alias CollegeTracker.ExtracurricularActivities.Activity
   alias CollegeTracker.ExtracurricularActivities.ActivityCategory
 
   @primary_key {:id, :binary_id, autogenerate: true}
@@ -64,6 +65,7 @@ defmodule CollegeTracker.ExtracurricularActivities.ActivityType do
     field :remaining_limit, :integer
 
     belongs_to :activity_category, ActivityCategory
+    has_many :activities, Activity
 
     timestamps()
   end

--- a/lib/college_tracker/extracurricular_activities/activity_type.ex
+++ b/lib/college_tracker/extracurricular_activities/activity_type.ex
@@ -1,0 +1,78 @@
+defmodule CollegeTracker.ExtracurricularActivities.ActivityType do
+  @moduledoc """
+  The ActivityType schema represents a specific type of extracurricular activity
+  within a certain category in the CollegeTracker application. Each activity type
+  has the following fields:
+
+    - :name - The name of the activity type (string). This could be "Congresso",
+      "Palestra", etc.
+
+    - :status - The status of the activity type (enum). This can take one of three
+      values: :unqualified, :available, or :complete. The status is used to
+      indicate whether the activity type is available for selection, already
+      completed or not qualified for completion.
+
+    - :total_limit - The total number of hours that can be assigned to the
+      activity type across all instances of it (integer). This is the cumulative
+      limit for this type of activity.
+
+    - :individual_limit - The maximum number of hours that can be assigned to a
+      single instance of the activity type (integer). For example, no matter how
+      long a single conference is, it may count for a maximum of 5 hours.
+
+    - :remaining_limit - The remaining number of hours that can be assigned to
+      the activity type (integer). This decreases as more activities of this type
+      are completed.
+
+    - :category_id - The binary_id of the category to which this activity type
+      belongs. This establishes a relationship between the ActivityType and its
+      parent ActivityCategory.
+
+  Each `ActivityType` also has automatically generated timestamps.
+  """
+
+  use Ecto.Schema
+
+  import Ecto.Changeset
+
+  alias CollegeTracker.ExtracurricularActivities.ActivityCategory
+
+  @primary_key {:id, :binary_id, autogenerate: true}
+  @foreign_key_type :binary_id
+
+  @type status :: :unqualified | :available | :complete
+
+  @type t :: %__MODULE__{
+          id: binary,
+          name: String.t(),
+          status: status,
+          total_limit: integer,
+          individual_limit: integer,
+          remaining_limit: integer,
+          activity_category: ActivityCategory.t(),
+          inserted_at: DateTime.t(),
+          updated_at: DateTime.t()
+        }
+
+  @required_fields ~w(name status total_limit individual_limit remaining_limit activity_category_id)a
+
+  schema "activity_types" do
+    field :name, :string
+    field :status, Ecto.Enum, values: [:unqualified, :available, :complete]
+    field :total_limit, :integer
+    field :individual_limit, :integer
+    field :remaining_limit, :integer
+
+    belongs_to :activity_category, ActivityCategory
+
+    timestamps()
+  end
+
+  @doc false
+  def changeset(activity_type, attrs) do
+    activity_type
+    |> cast(attrs, @required_fields)
+    |> validate_required(@required_fields)
+    |> assoc_constraint(:activity_category)
+  end
+end

--- a/lib/college_tracker_web/live/activity_category_live/form_component.ex
+++ b/lib/college_tracker_web/live/activity_category_live/form_component.ex
@@ -1,0 +1,94 @@
+defmodule CollegeTrackerWeb.ActivityCategoryLive.FormComponent do
+  use CollegeTrackerWeb, :live_component
+
+  alias CollegeTracker.ExtracurricularActivities
+
+  @impl true
+  def render(assigns) do
+    ~H"""
+    <div>
+      <.header>
+        <%= @title %>
+        <:subtitle>Use this form to manage activity_category records in your database.</:subtitle>
+      </.header>
+
+      <.simple_form
+        for={@form}
+        id="activity_category-form"
+        phx-target={@myself}
+        phx-change="validate"
+        phx-submit="save"
+      >
+        <.input field={@form[:name]} type="text" label="Name" />
+        <.input field={@form[:limit]} type="number" label="Limit" />
+        <:actions>
+          <.button phx-disable-with="Saving...">Save Activity category</.button>
+        </:actions>
+      </.simple_form>
+    </div>
+    """
+  end
+
+  @impl true
+  def update(%{activity_category: activity_category} = assigns, socket) do
+    changeset = ExtracurricularActivities.change_activity_category(activity_category)
+
+    {:ok,
+     socket
+     |> assign(assigns)
+     |> assign_form(changeset)}
+  end
+
+  @impl true
+  def handle_event("validate", %{"activity_category" => activity_category_params}, socket) do
+    changeset =
+      socket.assigns.activity_category
+      |> ExtracurricularActivities.change_activity_category(activity_category_params)
+      |> Map.put(:action, :validate)
+
+    {:noreply, assign_form(socket, changeset)}
+  end
+
+  def handle_event("save", %{"activity_category" => activity_category_params}, socket) do
+    save_activity_category(socket, socket.assigns.action, activity_category_params)
+  end
+
+  defp save_activity_category(socket, :edit, activity_category_params) do
+    case ExtracurricularActivities.update_activity_category(
+           socket.assigns.activity_category,
+           activity_category_params
+         ) do
+      {:ok, activity_category} ->
+        notify_parent({:saved, activity_category})
+
+        {:noreply,
+         socket
+         |> put_flash(:info, "Activity category updated successfully")
+         |> push_patch(to: socket.assigns.patch)}
+
+      {:error, %Ecto.Changeset{} = changeset} ->
+        {:noreply, assign_form(socket, changeset)}
+    end
+  end
+
+  defp save_activity_category(socket, :new, activity_category_params) do
+    case ExtracurricularActivities.create_activity_category(activity_category_params) do
+      {:ok, activity_category} ->
+        notify_parent({:saved, activity_category})
+
+        {:noreply,
+         socket
+         |> put_flash(:info, "Activity category created successfully")
+         |> push_patch(to: socket.assigns.patch)}
+
+      {:error, %Ecto.Changeset{} = changeset} ->
+        {:noreply, assign_form(socket, changeset)}
+    end
+  end
+
+  defp assign_form(socket, %Ecto.Changeset{} = changeset) do
+    assign(socket, :form, to_form(changeset))
+  end
+
+  defp notify_parent(msg), do: send(self(), {__MODULE__, msg})
+end

--- a/lib/college_tracker_web/live/activity_category_live/form_component.ex
+++ b/lib/college_tracker_web/live/activity_category_live/form_component.ex
@@ -20,7 +20,16 @@ defmodule CollegeTrackerWeb.ActivityCategoryLive.FormComponent do
         phx-submit="save"
       >
         <.input field={@form[:name]} type="text" label="Name" />
-        <.input field={@form[:limit]} type="number" label="Limit" />
+        <.input field={@form[:total_limit]} type="number" label="Total Limit" />
+        <.input field={@form[:remaining_limit]} type="number" label="Remaining Limit" />
+        <.input
+          field={@form[:status]}
+          type="select"
+          options={
+            Ecto.Enum.values(CollegeTracker.ExtracurricularActivities.ActivityCategory, :status)
+          }
+          label="Status"
+        />
         <:actions>
           <.button phx-disable-with="Saving...">Save Activity category</.button>
         </:actions>

--- a/lib/college_tracker_web/live/activity_category_live/index.ex
+++ b/lib/college_tracker_web/live/activity_category_live/index.ex
@@ -1,0 +1,51 @@
+defmodule CollegeTrackerWeb.ActivityCategoryLive.Index do
+  use CollegeTrackerWeb, :live_view
+
+  alias CollegeTracker.ExtracurricularActivities
+  alias CollegeTracker.ExtracurricularActivities.ActivityCategory
+
+  @impl true
+  def mount(_params, _session, socket) do
+    {:ok,
+     stream(socket, :activity_categories, ExtracurricularActivities.list_activity_categories())}
+  end
+
+  @impl true
+  def handle_params(params, _url, socket) do
+    {:noreply, apply_action(socket, socket.assigns.live_action, params)}
+  end
+
+  defp apply_action(socket, :edit, %{"id" => id}) do
+    socket
+    |> assign(:page_title, "Edit Activity category")
+    |> assign(:activity_category, ExtracurricularActivities.get_activity_category!(id))
+  end
+
+  defp apply_action(socket, :new, _params) do
+    socket
+    |> assign(:page_title, "New Activity category")
+    |> assign(:activity_category, %ActivityCategory{})
+  end
+
+  defp apply_action(socket, :index, _params) do
+    socket
+    |> assign(:page_title, "Listing Activity categories")
+    |> assign(:activity_category, nil)
+  end
+
+  @impl true
+  def handle_info(
+        {CollegeTrackerWeb.ActivityCategoryLive.FormComponent, {:saved, activity_category}},
+        socket
+      ) do
+    {:noreply, stream_insert(socket, :activity_categories, activity_category)}
+  end
+
+  @impl true
+  def handle_event("delete", %{"id" => id}, socket) do
+    activity_category = ExtracurricularActivities.get_activity_category!(id)
+    {:ok, _} = ExtracurricularActivities.delete_activity_category(activity_category)
+
+    {:noreply, stream_delete(socket, :activity_categories, activity_category)}
+  end
+end

--- a/lib/college_tracker_web/live/activity_category_live/index.html.heex
+++ b/lib/college_tracker_web/live/activity_category_live/index.html.heex
@@ -1,0 +1,49 @@
+<.header>
+  Listing Activity categories
+  <:actions>
+    <.link patch={~p"/activity_categories/new"}>
+      <.button>New Activity category</.button>
+    </.link>
+  </:actions>
+</.header>
+
+<.table
+  id="activity_categories"
+  rows={@streams.activity_categories}
+  row_click={
+    fn {_id, activity_category} -> JS.navigate(~p"/activity_categories/#{activity_category}") end
+  }
+>
+  <:col :let={{_id, activity_category}} label="Name"><%= activity_category.name %></:col>
+  <:col :let={{_id, activity_category}} label="Limit"><%= activity_category.limit %></:col>
+  <:action :let={{_id, activity_category}}>
+    <div class="sr-only">
+      <.link navigate={~p"/activity_categories/#{activity_category}"}>Show</.link>
+    </div>
+    <.link patch={~p"/activity_categories/#{activity_category}/edit"}>Edit</.link>
+  </:action>
+  <:action :let={{id, activity_category}}>
+    <.link
+      phx-click={JS.push("delete", value: %{id: activity_category.id}) |> hide("##{id}")}
+      data-confirm="Are you sure?"
+    >
+      Delete
+    </.link>
+  </:action>
+</.table>
+
+<.modal
+  :if={@live_action in [:new, :edit]}
+  id="activity_category-modal"
+  show
+  on_cancel={JS.patch(~p"/activity_categories")}
+>
+  <.live_component
+    module={CollegeTrackerWeb.ActivityCategoryLive.FormComponent}
+    id={@activity_category.id || :new}
+    title={@page_title}
+    action={@live_action}
+    activity_category={@activity_category}
+    patch={~p"/activity_categories"}
+  />
+</.modal>

--- a/lib/college_tracker_web/live/activity_category_live/index.html.heex
+++ b/lib/college_tracker_web/live/activity_category_live/index.html.heex
@@ -15,7 +15,13 @@
   }
 >
   <:col :let={{_id, activity_category}} label="Name"><%= activity_category.name %></:col>
-  <:col :let={{_id, activity_category}} label="Limit"><%= activity_category.limit %></:col>
+  <:col :let={{_id, activity_category}} label="Total Limit">
+    <%= activity_category.total_limit %>
+  </:col>
+  <:col :let={{_id, activity_category}} label="Remaining Limit">
+    <%= activity_category.remaining_limit %>
+  </:col>
+  <:col :let={{_id, activity_category}} label="Status"><%= activity_category.status %></:col>
   <:action :let={{_id, activity_category}}>
     <div class="sr-only">
       <.link navigate={~p"/activity_categories/#{activity_category}"}>Show</.link>

--- a/lib/college_tracker_web/live/activity_category_live/show.ex
+++ b/lib/college_tracker_web/live/activity_category_live/show.ex
@@ -1,0 +1,21 @@
+defmodule CollegeTrackerWeb.ActivityCategoryLive.Show do
+  use CollegeTrackerWeb, :live_view
+
+  alias CollegeTracker.ExtracurricularActivities
+
+  @impl true
+  def mount(_params, _session, socket) do
+    {:ok, socket}
+  end
+
+  @impl true
+  def handle_params(%{"id" => id}, _, socket) do
+    {:noreply,
+     socket
+     |> assign(:page_title, page_title(socket.assigns.live_action))
+     |> assign(:activity_category, ExtracurricularActivities.get_activity_category!(id))}
+  end
+
+  defp page_title(:show), do: "Show Activity category"
+  defp page_title(:edit), do: "Edit Activity category"
+end

--- a/lib/college_tracker_web/live/activity_category_live/show.html.heex
+++ b/lib/college_tracker_web/live/activity_category_live/show.html.heex
@@ -13,7 +13,9 @@
 
 <.list>
   <:item title="Name"><%= @activity_category.name %></:item>
-  <:item title="Limit"><%= @activity_category.limit %></:item>
+  <:item title="Total Limit"><%= @activity_category.total_limit %></:item>
+  <:item title="Remaining Limit"><%= @activity_category.remaining_limit %></:item>
+  <:item title="Status"><%= @activity_category.status %></:item>
 </.list>
 
 <.back navigate={~p"/activity_categories"}>Back to activity_categories</.back>

--- a/lib/college_tracker_web/live/activity_category_live/show.html.heex
+++ b/lib/college_tracker_web/live/activity_category_live/show.html.heex
@@ -1,0 +1,35 @@
+<.header>
+  Activity category <%= @activity_category.id %>
+  <:subtitle>This is a activity_category record from your database.</:subtitle>
+  <:actions>
+    <.link
+      patch={~p"/activity_categories/#{@activity_category}/show/edit"}
+      phx-click={JS.push_focus()}
+    >
+      <.button>Edit activity_category</.button>
+    </.link>
+  </:actions>
+</.header>
+
+<.list>
+  <:item title="Name"><%= @activity_category.name %></:item>
+  <:item title="Limit"><%= @activity_category.limit %></:item>
+</.list>
+
+<.back navigate={~p"/activity_categories"}>Back to activity_categories</.back>
+
+<.modal
+  :if={@live_action == :edit}
+  id="activity_category-modal"
+  show
+  on_cancel={JS.patch(~p"/activity_categories/#{@activity_category}")}
+>
+  <.live_component
+    module={CollegeTrackerWeb.ActivityCategoryLive.FormComponent}
+    id={@activity_category.id}
+    title={@page_title}
+    action={@live_action}
+    activity_category={@activity_category}
+    patch={~p"/activity_categories/#{@activity_category}"}
+  />
+</.modal>

--- a/lib/college_tracker_web/live/activity_live/form_component.ex
+++ b/lib/college_tracker_web/live/activity_live/form_component.ex
@@ -1,0 +1,115 @@
+defmodule CollegeTrackerWeb.ActivityLive.FormComponent do
+  use CollegeTrackerWeb, :live_component
+
+  alias CollegeTracker.ExtracurricularActivities
+  alias CollegeTracker.Repo
+
+  @impl true
+  def render(assigns) do
+    ~H"""
+    <div>
+      <.header>
+        <%= @title %>
+        <:subtitle>Use this form to manage activity records in your database.</:subtitle>
+      </.header>
+
+      <.simple_form
+        for={@form}
+        id="activity-form"
+        phx-target={@myself}
+        phx-change="validate"
+        phx-submit="save"
+      >
+        <.input
+          field={@form[:activity_type_id]}
+          type="select"
+          label="Activity Type"
+          prompt="Choose a type"
+          options={@type_options}
+        />
+        <.input field={@form[:name]} type="text" label="Name" />
+        <.input field={@form[:description]} type="text" label="Description" />
+        <.input
+          field={@form[:status]}
+          type="select"
+          label="Status"
+          prompt="Choose a value"
+          options={Ecto.Enum.values(CollegeTracker.ExtracurricularActivities.Activity, :status)}
+        />
+        <.input field={@form[:hours]} type="number" label="Hours" />
+        <.input field={@form[:start_date]} type="date" label="Start date" />
+        <.input field={@form[:end_date]} type="date" label="End date" />
+        <.input field={@form[:submission_date]} type="date" label="Submission date" />
+        <.input field={@form[:certificate]} type="text" label="Certificate" />
+        <:actions>
+          <.button phx-disable-with="Saving...">Save Activity</.button>
+        </:actions>
+      </.simple_form>
+    </div>
+    """
+  end
+
+  @impl true
+  def update(%{activity: activity} = assigns, socket) do
+    changeset = ExtracurricularActivities.change_activity(activity)
+
+    types = Repo.all(ExtracurricularActivities.ActivityType)
+    type_options = for type <- types, do: {type.name, type.id}
+
+    {:ok,
+     socket
+     |> assign(assigns)
+     |> assign_form(changeset)
+     |> assign(type_options: type_options)}
+  end
+
+  @impl true
+  def handle_event("validate", %{"activity" => activity_params}, socket) do
+    changeset =
+      socket.assigns.activity
+      |> ExtracurricularActivities.change_activity(activity_params)
+      |> Map.put(:action, :validate)
+
+    {:noreply, assign_form(socket, changeset)}
+  end
+
+  def handle_event("save", %{"activity" => activity_params}, socket) do
+    save_activity(socket, socket.assigns.action, activity_params)
+  end
+
+  defp save_activity(socket, :edit, activity_params) do
+    case ExtracurricularActivities.update_activity(socket.assigns.activity, activity_params) do
+      {:ok, activity} ->
+        notify_parent({:saved, activity})
+
+        {:noreply,
+         socket
+         |> put_flash(:info, "Activity updated successfully")
+         |> push_patch(to: socket.assigns.patch)}
+
+      {:error, %Ecto.Changeset{} = changeset} ->
+        {:noreply, assign_form(socket, changeset)}
+    end
+  end
+
+  defp save_activity(socket, :new, activity_params) do
+    case ExtracurricularActivities.create_activity(activity_params) do
+      {:ok, activity} ->
+        notify_parent({:saved, activity})
+
+        {:noreply,
+         socket
+         |> put_flash(:info, "Activity created successfully")
+         |> push_patch(to: socket.assigns.patch)}
+
+      {:error, %Ecto.Changeset{} = changeset} ->
+        {:noreply, assign_form(socket, changeset)}
+    end
+  end
+
+  defp assign_form(socket, %Ecto.Changeset{} = changeset) do
+    assign(socket, :form, to_form(changeset))
+  end
+
+  defp notify_parent(msg), do: send(self(), {__MODULE__, msg})
+end

--- a/lib/college_tracker_web/live/activity_live/index.ex
+++ b/lib/college_tracker_web/live/activity_live/index.ex
@@ -1,0 +1,47 @@
+defmodule CollegeTrackerWeb.ActivityLive.Index do
+  use CollegeTrackerWeb, :live_view
+
+  alias CollegeTracker.ExtracurricularActivities
+  alias CollegeTracker.ExtracurricularActivities.Activity
+
+  @impl true
+  def mount(_params, _session, socket) do
+    {:ok, stream(socket, :activities, ExtracurricularActivities.list_activities())}
+  end
+
+  @impl true
+  def handle_params(params, _url, socket) do
+    {:noreply, apply_action(socket, socket.assigns.live_action, params)}
+  end
+
+  defp apply_action(socket, :edit, %{"id" => id}) do
+    socket
+    |> assign(:page_title, "Edit Activity")
+    |> assign(:activity, ExtracurricularActivities.get_activity!(id))
+  end
+
+  defp apply_action(socket, :new, _params) do
+    socket
+    |> assign(:page_title, "New Activity")
+    |> assign(:activity, %Activity{})
+  end
+
+  defp apply_action(socket, :index, _params) do
+    socket
+    |> assign(:page_title, "Listing Activities")
+    |> assign(:activity, nil)
+  end
+
+  @impl true
+  def handle_info({CollegeTrackerWeb.ActivityLive.FormComponent, {:saved, activity}}, socket) do
+    {:noreply, stream_insert(socket, :activities, activity)}
+  end
+
+  @impl true
+  def handle_event("delete", %{"id" => id}, socket) do
+    activity = ExtracurricularActivities.get_activity!(id)
+    {:ok, _} = ExtracurricularActivities.delete_activity(activity)
+
+    {:noreply, stream_delete(socket, :activities, activity)}
+  end
+end

--- a/lib/college_tracker_web/live/activity_live/index.html.heex
+++ b/lib/college_tracker_web/live/activity_live/index.html.heex
@@ -1,0 +1,53 @@
+<.header>
+  Listing Activities
+  <:actions>
+    <.link patch={~p"/activities/new"}>
+      <.button>New Activity</.button>
+    </.link>
+  </:actions>
+</.header>
+
+<.table
+  id="activities"
+  rows={@streams.activities}
+  row_click={fn {_id, activity} -> JS.navigate(~p"/activities/#{activity}") end}
+>
+  <:col :let={{_id, activity}} label="Name"><%= activity.name %></:col>
+  <:col :let={{_id, activity}} label="Description"><%= activity.description %></:col>
+  <:col :let={{_id, activity}} label="Status"><%= activity.status %></:col>
+  <:col :let={{_id, activity}} label="Hours"><%= activity.hours %></:col>
+  <:col :let={{_id, activity}} label="Start date"><%= activity.start_date %></:col>
+  <:col :let={{_id, activity}} label="End date"><%= activity.end_date %></:col>
+  <:col :let={{_id, activity}} label="Submission date"><%= activity.submission_date %></:col>
+  <:col :let={{_id, activity}} label="Certificate"><%= activity.certificate %></:col>
+  <:action :let={{_id, activity}}>
+    <div class="sr-only">
+      <.link navigate={~p"/activities/#{activity}"}>Show</.link>
+    </div>
+    <.link patch={~p"/activities/#{activity}/edit"}>Edit</.link>
+  </:action>
+  <:action :let={{id, activity}}>
+    <.link
+      phx-click={JS.push("delete", value: %{id: activity.id}) |> hide("##{id}")}
+      data-confirm="Are you sure?"
+    >
+      Delete
+    </.link>
+  </:action>
+</.table>
+
+<.modal
+  :if={@live_action in [:new, :edit]}
+  id="activity-modal"
+  show
+  on_cancel={JS.patch(~p"/activities")}
+>
+  <.live_component
+    module={CollegeTrackerWeb.ActivityLive.FormComponent}
+    id={@activity.id || :new}
+    title={@page_title}
+    action={@live_action}
+    activity={@activity}
+    patch={~p"/activities"}
+  />
+</.modal>

--- a/lib/college_tracker_web/live/activity_live/show.ex
+++ b/lib/college_tracker_web/live/activity_live/show.ex
@@ -1,0 +1,21 @@
+defmodule CollegeTrackerWeb.ActivityLive.Show do
+  use CollegeTrackerWeb, :live_view
+
+  alias CollegeTracker.ExtracurricularActivities
+
+  @impl true
+  def mount(_params, _session, socket) do
+    {:ok, socket}
+  end
+
+  @impl true
+  def handle_params(%{"id" => id}, _, socket) do
+    {:noreply,
+     socket
+     |> assign(:page_title, page_title(socket.assigns.live_action))
+     |> assign(:activity, ExtracurricularActivities.get_activity!(id))}
+  end
+
+  defp page_title(:show), do: "Show Activity"
+  defp page_title(:edit), do: "Edit Activity"
+end

--- a/lib/college_tracker_web/live/activity_live/show.html.heex
+++ b/lib/college_tracker_web/live/activity_live/show.html.heex
@@ -1,0 +1,38 @@
+<.header>
+  Activity <%= @activity.id %>
+  <:subtitle>This is a activity record from your database.</:subtitle>
+  <:actions>
+    <.link patch={~p"/activities/#{@activity}/show/edit"} phx-click={JS.push_focus()}>
+      <.button>Edit activity</.button>
+    </.link>
+  </:actions>
+</.header>
+
+<.list>
+  <:item title="Name"><%= @activity.name %></:item>
+  <:item title="Description"><%= @activity.description %></:item>
+  <:item title="Status"><%= @activity.status %></:item>
+  <:item title="Hours"><%= @activity.hours %></:item>
+  <:item title="Start date"><%= @activity.start_date %></:item>
+  <:item title="End date"><%= @activity.end_date %></:item>
+  <:item title="Submission date"><%= @activity.submission_date %></:item>
+  <:item title="Certificate"><%= @activity.certificate %></:item>
+</.list>
+
+<.back navigate={~p"/activities"}>Back to activities</.back>
+
+<.modal
+  :if={@live_action == :edit}
+  id="activity-modal"
+  show
+  on_cancel={JS.patch(~p"/activities/#{@activity}")}
+>
+  <.live_component
+    module={CollegeTrackerWeb.ActivityLive.FormComponent}
+    id={@activity.id}
+    title={@page_title}
+    action={@live_action}
+    activity={@activity}
+    patch={~p"/activities/#{@activity}"}
+  />
+</.modal>

--- a/lib/college_tracker_web/live/activity_type_live/form_component.ex
+++ b/lib/college_tracker_web/live/activity_type_live/form_component.ex
@@ -1,0 +1,116 @@
+defmodule CollegeTrackerWeb.ActivityTypeLive.FormComponent do
+  use CollegeTrackerWeb, :live_component
+
+  alias CollegeTracker.ExtracurricularActivities
+  alias CollegeTracker.Repo
+
+  @impl true
+  def render(assigns) do
+    ~H"""
+    <div>
+      <.header>
+        <%= @title %>
+        <:subtitle>Use this form to manage activity_type records in your database.</:subtitle>
+      </.header>
+
+      <.simple_form
+        for={@form}
+        id="activity_type-form"
+        phx-target={@myself}
+        phx-change="validate"
+        phx-submit="save"
+      >
+        <.input field={@form[:name]} type="text" label="Name" />
+        <.input field={@form[:total_limit]} type="number" label="Total limit" />
+        <.input field={@form[:individual_limit]} type="number" label="Individual limit" />
+        <.input field={@form[:remaining_limit]} type="number" label="Remaining limit" />
+        <.input
+          field={@form[:status]}
+          type="select"
+          label="Status"
+          prompt="Choose a value"
+          options={Ecto.Enum.values(CollegeTracker.ExtracurricularActivities.ActivityType, :status)}
+        />
+        <.input
+          field={@form[:activity_category_id]}
+          type="select"
+          label="Activity Category"
+          prompt="Choose a category"
+          options={@category_options}
+        />
+
+        <:actions>
+          <.button phx-disable-with="Saving...">Save Activity type</.button>
+        </:actions>
+      </.simple_form>
+    </div>
+    """
+  end
+
+  @impl true
+  def update(%{activity_type: activity_type} = assigns, socket) do
+    changeset = ExtracurricularActivities.change_activity_type(activity_type)
+
+    categories = Repo.all(ExtracurricularActivities.ActivityCategory)
+    category_options = for category <- categories, do: {category.name, category.id}
+
+    {:ok,
+     socket
+     |> assign(assigns)
+     |> assign_form(changeset)
+     |> assign(:category_options, category_options)}
+  end
+
+  @impl true
+  def handle_event("validate", %{"activity_type" => activity_type_params}, socket) do
+    changeset =
+      socket.assigns.activity_type
+      |> ExtracurricularActivities.change_activity_type(activity_type_params)
+      |> Map.put(:action, :validate)
+
+    {:noreply, assign_form(socket, changeset)}
+  end
+
+  def handle_event("save", %{"activity_type" => activity_type_params}, socket) do
+    save_activity_type(socket, socket.assigns.action, activity_type_params)
+  end
+
+  defp save_activity_type(socket, :edit, activity_type_params) do
+    case ExtracurricularActivities.update_activity_type(
+           socket.assigns.activity_type,
+           activity_type_params
+         ) do
+      {:ok, activity_type} ->
+        notify_parent({:saved, activity_type})
+
+        {:noreply,
+         socket
+         |> put_flash(:info, "Activity type updated successfully")
+         |> push_patch(to: socket.assigns.patch)}
+
+      {:error, %Ecto.Changeset{} = changeset} ->
+        {:noreply, assign_form(socket, changeset)}
+    end
+  end
+
+  defp save_activity_type(socket, :new, activity_type_params) do
+    case ExtracurricularActivities.create_activity_type(activity_type_params) do
+      {:ok, activity_type} ->
+        notify_parent({:saved, activity_type})
+
+        {:noreply,
+         socket
+         |> put_flash(:info, "Activity type created successfully")
+         |> push_patch(to: socket.assigns.patch)}
+
+      {:error, %Ecto.Changeset{} = changeset} ->
+        {:noreply, assign_form(socket, changeset)}
+    end
+  end
+
+  defp assign_form(socket, %Ecto.Changeset{} = changeset) do
+    assign(socket, :form, to_form(changeset))
+  end
+
+  defp notify_parent(msg), do: send(self(), {__MODULE__, msg})
+end

--- a/lib/college_tracker_web/live/activity_type_live/index.ex
+++ b/lib/college_tracker_web/live/activity_type_live/index.ex
@@ -1,0 +1,50 @@
+defmodule CollegeTrackerWeb.ActivityTypeLive.Index do
+  use CollegeTrackerWeb, :live_view
+
+  alias CollegeTracker.ExtracurricularActivities
+  alias CollegeTracker.ExtracurricularActivities.ActivityType
+
+  @impl true
+  def mount(_params, _session, socket) do
+    {:ok, stream(socket, :activity_types, ExtracurricularActivities.list_activity_types())}
+  end
+
+  @impl true
+  def handle_params(params, _url, socket) do
+    {:noreply, apply_action(socket, socket.assigns.live_action, params)}
+  end
+
+  defp apply_action(socket, :edit, %{"id" => id}) do
+    socket
+    |> assign(:page_title, "Edit Activity type")
+    |> assign(:activity_type, ExtracurricularActivities.get_activity_type!(id))
+  end
+
+  defp apply_action(socket, :new, _params) do
+    socket
+    |> assign(:page_title, "New Activity type")
+    |> assign(:activity_type, %ActivityType{})
+  end
+
+  defp apply_action(socket, :index, _params) do
+    socket
+    |> assign(:page_title, "Listing Activity types")
+    |> assign(:activity_type, nil)
+  end
+
+  @impl true
+  def handle_info(
+        {CollegeTrackerWeb.ActivityTypeLive.FormComponent, {:saved, activity_type}},
+        socket
+      ) do
+    {:noreply, stream_insert(socket, :activity_types, activity_type)}
+  end
+
+  @impl true
+  def handle_event("delete", %{"id" => id}, socket) do
+    activity_type = ExtracurricularActivities.get_activity_type!(id)
+    {:ok, _} = ExtracurricularActivities.delete_activity_type(activity_type)
+
+    {:noreply, stream_delete(socket, :activity_types, activity_type)}
+  end
+end

--- a/lib/college_tracker_web/live/activity_type_live/index.html.heex
+++ b/lib/college_tracker_web/live/activity_type_live/index.html.heex
@@ -1,0 +1,54 @@
+<.header>
+  Listing Activity types
+  <:actions>
+    <.link patch={~p"/activity_types/new"}>
+      <.button>New Activity type</.button>
+    </.link>
+  </:actions>
+</.header>
+
+<.table
+  id="activity_types"
+  rows={@streams.activity_types}
+  row_click={fn {_id, activity_type} -> JS.navigate(~p"/activity_types/#{activity_type}") end}
+>
+  <:col :let={{_id, activity_type}} label="Name"><%= activity_type.name %></:col>
+  <:col :let={{_id, activity_type}} label="Total limit"><%= activity_type.total_limit %></:col>
+  <:col :let={{_id, activity_type}} label="Individual limit">
+    <%= activity_type.individual_limit %>
+  </:col>
+  <:col :let={{_id, activity_type}} label="Remaining limit">
+    <%= activity_type.remaining_limit %>
+  </:col>
+  <:col :let={{_id, activity_type}} label="Status"><%= activity_type.status %></:col>
+  <:action :let={{_id, activity_type}}>
+    <div class="sr-only">
+      <.link navigate={~p"/activity_types/#{activity_type}"}>Show</.link>
+    </div>
+    <.link patch={~p"/activity_types/#{activity_type}/edit"}>Edit</.link>
+  </:action>
+  <:action :let={{id, activity_type}}>
+    <.link
+      phx-click={JS.push("delete", value: %{id: activity_type.id}) |> hide("##{id}")}
+      data-confirm="Are you sure?"
+    >
+      Delete
+    </.link>
+  </:action>
+</.table>
+
+<.modal
+  :if={@live_action in [:new, :edit]}
+  id="activity_type-modal"
+  show
+  on_cancel={JS.patch(~p"/activity_types")}
+>
+  <.live_component
+    module={CollegeTrackerWeb.ActivityTypeLive.FormComponent}
+    id={@activity_type.id || :new}
+    title={@page_title}
+    action={@live_action}
+    activity_type={@activity_type}
+    patch={~p"/activity_types"}
+  />
+</.modal>

--- a/lib/college_tracker_web/live/activity_type_live/show.ex
+++ b/lib/college_tracker_web/live/activity_type_live/show.ex
@@ -1,0 +1,21 @@
+defmodule CollegeTrackerWeb.ActivityTypeLive.Show do
+  use CollegeTrackerWeb, :live_view
+
+  alias CollegeTracker.ExtracurricularActivities
+
+  @impl true
+  def mount(_params, _session, socket) do
+    {:ok, socket}
+  end
+
+  @impl true
+  def handle_params(%{"id" => id}, _, socket) do
+    {:noreply,
+     socket
+     |> assign(:page_title, page_title(socket.assigns.live_action))
+     |> assign(:activity_type, ExtracurricularActivities.get_activity_type!(id))}
+  end
+
+  defp page_title(:show), do: "Show Activity type"
+  defp page_title(:edit), do: "Edit Activity type"
+end

--- a/lib/college_tracker_web/live/activity_type_live/show.html.heex
+++ b/lib/college_tracker_web/live/activity_type_live/show.html.heex
@@ -1,0 +1,35 @@
+<.header>
+  Activity type <%= @activity_type.id %>
+  <:subtitle>This is a activity_type record from your database.</:subtitle>
+  <:actions>
+    <.link patch={~p"/activity_types/#{@activity_type}/show/edit"} phx-click={JS.push_focus()}>
+      <.button>Edit activity_type</.button>
+    </.link>
+  </:actions>
+</.header>
+
+<.list>
+  <:item title="Name"><%= @activity_type.name %></:item>
+  <:item title="Total limit"><%= @activity_type.total_limit %></:item>
+  <:item title="Individual limit"><%= @activity_type.individual_limit %></:item>
+  <:item title="Remaining limit"><%= @activity_type.remaining_limit %></:item>
+  <:item title="Status"><%= @activity_type.status %></:item>
+</.list>
+
+<.back navigate={~p"/activity_types"}>Back to activity_types</.back>
+
+<.modal
+  :if={@live_action == :edit}
+  id="activity_type-modal"
+  show
+  on_cancel={JS.patch(~p"/activity_types/#{@activity_type}")}
+>
+  <.live_component
+    module={CollegeTrackerWeb.ActivityTypeLive.FormComponent}
+    id={@activity_type.id}
+    title={@page_title}
+    action={@live_action}
+    activity_type={@activity_type}
+    patch={~p"/activity_types/#{@activity_type}"}
+  />
+</.modal>

--- a/lib/college_tracker_web/router.ex
+++ b/lib/college_tracker_web/router.ex
@@ -31,6 +31,13 @@ defmodule CollegeTrackerWeb.Router do
 
     live "/activity_types/:id", ActivityTypeLive.Show, :show
     live "/activity_types/:id/show/edit", ActivityTypeLive.Show, :edit
+
+    live "/activities", ActivityLive.Index, :index
+    live "/activities/new", ActivityLive.Index, :new
+    live "/activities/:id/edit", ActivityLive.Index, :edit
+
+    live "/activities/:id", ActivityLive.Show, :show
+    live "/activities/:id/show/edit", ActivityLive.Show, :edit
   end
 
   # Other scopes may use custom stacks.

--- a/lib/college_tracker_web/router.ex
+++ b/lib/college_tracker_web/router.ex
@@ -18,6 +18,12 @@ defmodule CollegeTrackerWeb.Router do
     pipe_through :browser
 
     get "/", PageController, :home
+    live "/activity_categories", ActivityCategoryLive.Index, :index
+    live "/activity_categories/new", ActivityCategoryLive.Index, :new
+    live "/activity_categories/:id/edit", ActivityCategoryLive.Index, :edit
+
+    live "/activity_categories/:id", ActivityCategoryLive.Show, :show
+    live "/activity_categories/:id/show/edit", ActivityCategoryLive.Show, :edit
   end
 
   # Other scopes may use custom stacks.

--- a/lib/college_tracker_web/router.ex
+++ b/lib/college_tracker_web/router.ex
@@ -24,6 +24,13 @@ defmodule CollegeTrackerWeb.Router do
 
     live "/activity_categories/:id", ActivityCategoryLive.Show, :show
     live "/activity_categories/:id/show/edit", ActivityCategoryLive.Show, :edit
+
+    live "/activity_types", ActivityTypeLive.Index, :index
+    live "/activity_types/new", ActivityTypeLive.Index, :new
+    live "/activity_types/:id/edit", ActivityTypeLive.Index, :edit
+
+    live "/activity_types/:id", ActivityTypeLive.Show, :show
+    live "/activity_types/:id/show/edit", ActivityTypeLive.Show, :edit
   end
 
   # Other scopes may use custom stacks.

--- a/priv/repo/migrations/20230616154223_create_activity_categories.exs
+++ b/priv/repo/migrations/20230616154223_create_activity_categories.exs
@@ -1,0 +1,14 @@
+defmodule CollegeTracker.Repo.Migrations.CreateActivityCategories do
+  @moduledoc false
+  use Ecto.Migration
+
+  def change do
+    create table(:activity_categories, primary_key: false) do
+      add :id, :binary_id, primary_key: true
+      add :name, :text, null: false
+      add :limit, :integer, null: false
+
+      timestamps()
+    end
+  end
+end

--- a/priv/repo/migrations/20230616154223_create_activity_categories.exs
+++ b/priv/repo/migrations/20230616154223_create_activity_categories.exs
@@ -6,7 +6,9 @@ defmodule CollegeTracker.Repo.Migrations.CreateActivityCategories do
     create table(:activity_categories, primary_key: false) do
       add :id, :binary_id, primary_key: true
       add :name, :text, null: false
-      add :limit, :integer, null: false
+      add :total_limit, :integer, null: false
+      add :remaining_limit, :integer, null: false
+      add :status, :string, null: false
 
       timestamps()
     end

--- a/priv/repo/migrations/20230616181316_create_activity_types.exs
+++ b/priv/repo/migrations/20230616181316_create_activity_types.exs
@@ -1,0 +1,23 @@
+defmodule CollegeTracker.Repo.Migrations.CreateActivityTypes do
+  @moduledoc false
+  use Ecto.Migration
+
+  def change do
+    create table(:activity_types, primary_key: false) do
+      add :id, :binary_id, primary_key: true
+      add :name, :text, null: false
+      add :total_limit, :integer, null: false
+      add :individual_limit, :integer, null: false
+      add :remaining_limit, :integer, null: false
+      add :status, :string, null: false
+
+      add :activity_category_id,
+          references(:activity_categories, on_delete: :nothing, type: :binary_id),
+          null: false
+
+      timestamps()
+    end
+
+    create index(:activity_types, [:activity_category_id])
+  end
+end

--- a/priv/repo/migrations/20230616204717_create_activities.exs
+++ b/priv/repo/migrations/20230616204717_create_activities.exs
@@ -1,0 +1,23 @@
+defmodule CollegeTracker.Repo.Migrations.CreateActivities do
+  @moduledoc false
+  use Ecto.Migration
+
+  def change do
+    create table(:activities, primary_key: false) do
+      add :id, :binary_id, primary_key: true
+      add :name, :text, null: false
+      add :description, :text
+      add :status, :string, null: false
+      add :hours, :integer, null: false
+      add :start_date, :date
+      add :end_date, :date
+      add :submission_date, :date
+      add :certificate, :string
+      add :activity_type_id, references(:activity_types, on_delete: :nothing, type: :binary_id)
+
+      timestamps()
+    end
+
+    create index(:activities, [:activity_type_id])
+  end
+end

--- a/priv/repo/seeds.exs
+++ b/priv/repo/seeds.exs
@@ -17,13 +17,29 @@ end
 
 if Mix.env() != :test do
   # Insert activity categories
-  palestras_e_eventos = Repo.insert!(%ActivityCategory{name: "Palestras e Eventos", limit: 50})
+  palestras_e_eventos =
+    Repo.insert!(%ActivityCategory{
+      name: "Palestras e Eventos",
+      total_limit: 50,
+      remaining_limit: 50,
+      status: :available
+    })
 
   cursos_e_estudos_do_meio =
-    Repo.insert!(%ActivityCategory{name: "Cursos e Estudos do Meio", limit: 50})
+    Repo.insert!(%ActivityCategory{
+      name: "Cursos e Estudos do Meio",
+      total_limit: 50,
+      remaining_limit: 50,
+      status: :available
+    })
 
   atividades_e_praticas_profissionais =
-    Repo.insert!(%ActivityCategory{name: "Atividades e Práticas Profissionais", limit: 60})
+    Repo.insert!(%ActivityCategory{
+      name: "Atividades e Práticas Profissionais",
+      total_limit: 60,
+      remaining_limit: 60,
+      status: :available
+    })
 
   # Activity types for each category
   palestras_activity_types = [

--- a/priv/repo/seeds.exs
+++ b/priv/repo/seeds.exs
@@ -1,19 +1,62 @@
-# Script for populating the database. You can run it as:
-#
-#     mix run priv/repo/seeds.exs
-#
-# Inside the script, you can read and write to any of your
-# repositories directly:
-#
-#     CollegeTracker.Repo.insert!(%CollegeTracker.SomeSchema{})
-#
-# We recommend using the bang functions (`insert!`, `update!`
-# and so on) as they will fail if something goes wrong.
+# priv/repo/seeds.exs
 
 alias CollegeTracker.ExtracurricularActivities.ActivityCategory
+alias CollegeTracker.ExtracurricularActivities.ActivityType
 alias CollegeTracker.Repo
 
-# Insert activity categories
-Repo.insert!(%ActivityCategory{name: "Palestras e Eventos", limit: 50})
-Repo.insert!(%ActivityCategory{name: "Cursos e Estudos do Meio", limit: 50})
-Repo.insert!(%ActivityCategory{name: "Atividades e Práticas Profissionais", limit: 60})
+insert_activity_type = fn category_id, {name, total_limit, individual_limit} ->
+  Repo.insert!(%ActivityType{
+    name: name,
+    total_limit: total_limit,
+    individual_limit: individual_limit,
+    remaining_limit: total_limit,
+    status: :available,
+    activity_category_id: category_id
+  })
+end
+
+if Mix.env() != :test do
+  # Insert activity categories
+  palestras_e_eventos = Repo.insert!(%ActivityCategory{name: "Palestras e Eventos", limit: 50})
+
+  cursos_e_estudos_do_meio =
+    Repo.insert!(%ActivityCategory{name: "Cursos e Estudos do Meio", limit: 50})
+
+  atividades_e_praticas_profissionais =
+    Repo.insert!(%ActivityCategory{name: "Atividades e Práticas Profissionais", limit: 60})
+
+  # Activity types for each category
+  palestras_activity_types = [
+    {"Congresso (ouvinte / apresentação de trabalho)", 20, 5},
+    {"Palestra", 20, 2},
+    {"Presença em Defesa de Dissertação e Tese", 20, 2},
+    {"Semana Profissional", 20, 5},
+    {"Desenvolvimento e Apresentação de Trabalho de Iniciação Científica", 20, 4},
+    {"Outros (depende de aprovação)", 20, 1}
+  ]
+
+  cursos_activity_types = [
+    {"Curso da Área", 30, 5},
+    {"Visita Orientada à Espaços Externos Significativos", 20, 4},
+    {"Curso de Línguas ou de Especializações na Área (ao menos 100h)", 20, 20},
+    {"Outros (depende de aprovação)", 20, 1}
+  ]
+
+  atividades_activity_types = [
+    {"Atividade de Monitoria na Faculdade", 20, 6},
+    {"Atividade de Monitoria Externa", 20, 5},
+    {"Atividade de Estágio não obrigatório (ao menos 100h)", 30, 30},
+    {"Trabalho Voluntário na Área (ao menos 100h)", 20, 20},
+    {"Atuação Profissional na Área (ao menos 100h)", 30, 30},
+    {"Outros (depende de aprovação)", 20, 1}
+  ]
+
+  # Insert activity types
+  Enum.each(palestras_activity_types, &insert_activity_type.(palestras_e_eventos.id, &1))
+  Enum.each(cursos_activity_types, &insert_activity_type.(cursos_e_estudos_do_meio.id, &1))
+
+  Enum.each(
+    atividades_activity_types,
+    &insert_activity_type.(atividades_e_praticas_profissionais.id, &1)
+  )
+end

--- a/priv/repo/seeds.exs
+++ b/priv/repo/seeds.exs
@@ -9,3 +9,11 @@
 #
 # We recommend using the bang functions (`insert!`, `update!`
 # and so on) as they will fail if something goes wrong.
+
+alias CollegeTracker.ExtracurricularActivities.ActivityCategory
+alias CollegeTracker.Repo
+
+# Insert activity categories
+Repo.insert!(%ActivityCategory{name: "Palestras e Eventos", limit: 50})
+Repo.insert!(%ActivityCategory{name: "Cursos e Estudos do Meio", limit: 50})
+Repo.insert!(%ActivityCategory{name: "Atividades e Práticas Profissionais", limit: 60})

--- a/test/college_tracker/extracurricular_activities_test.exs
+++ b/test/college_tracker/extracurricular_activities_test.exs
@@ -1,0 +1,82 @@
+defmodule CollegeTracker.ExtracurricularActivitiesTest do
+  @moduledoc false
+  use CollegeTracker.DataCase
+
+  import CollegeTracker.ExtracurricularActivitiesFixtures
+
+  alias CollegeTracker.ExtracurricularActivities
+  alias CollegeTracker.ExtracurricularActivities.ActivityCategory
+
+  describe "activity_categories" do
+    @invalid_attrs %{limit: nil, name: nil}
+
+    test "list_activity_categories/0 returns all activity_categories" do
+      activity_category = activity_category_fixture()
+      assert ExtracurricularActivities.list_activity_categories() == [activity_category]
+    end
+
+    test "get_activity_category!/1 returns the activity_category with given id" do
+      activity_category = activity_category_fixture()
+
+      assert ExtracurricularActivities.get_activity_category!(activity_category.id) ==
+               activity_category
+    end
+
+    test "create_activity_category/1 with valid data creates a activity_category" do
+      valid_attrs = %{limit: 42, name: "some name"}
+
+      assert {:ok, %ActivityCategory{} = activity_category} =
+               ExtracurricularActivities.create_activity_category(valid_attrs)
+
+      assert activity_category.limit == 42
+      assert activity_category.name == "some name"
+    end
+
+    test "create_activity_category/1 with invalid data returns error changeset" do
+      assert {:error, %Ecto.Changeset{}} =
+               ExtracurricularActivities.create_activity_category(@invalid_attrs)
+    end
+
+    test "update_activity_category/2 with valid data updates the activity_category" do
+      activity_category = activity_category_fixture()
+      update_attrs = %{limit: 43, name: "some updated name"}
+
+      assert {:ok, %ActivityCategory{} = activity_category} =
+               ExtracurricularActivities.update_activity_category(activity_category, update_attrs)
+
+      assert activity_category.limit == 43
+      assert activity_category.name == "some updated name"
+    end
+
+    test "update_activity_category/2 with invalid data returns error changeset" do
+      activity_category = activity_category_fixture()
+
+      assert {:error, %Ecto.Changeset{}} =
+               ExtracurricularActivities.update_activity_category(
+                 activity_category,
+                 @invalid_attrs
+               )
+
+      assert activity_category ==
+               ExtracurricularActivities.get_activity_category!(activity_category.id)
+    end
+
+    test "delete_activity_category/1 deletes the activity_category" do
+      activity_category = activity_category_fixture()
+
+      assert {:ok, %ActivityCategory{}} =
+               ExtracurricularActivities.delete_activity_category(activity_category)
+
+      assert_raise Ecto.NoResultsError, fn ->
+        ExtracurricularActivities.get_activity_category!(activity_category.id)
+      end
+    end
+
+    test "change_activity_category/1 returns a activity_category changeset" do
+      activity_category = activity_category_fixture()
+
+      assert %Ecto.Changeset{} =
+               ExtracurricularActivities.change_activity_category(activity_category)
+    end
+  end
+end

--- a/test/college_tracker/extracurricular_activities_test.exs
+++ b/test/college_tracker/extracurricular_activities_test.exs
@@ -9,7 +9,7 @@ defmodule CollegeTracker.ExtracurricularActivitiesTest do
   alias CollegeTracker.ExtracurricularActivities.ActivityType
 
   describe "activity_categories" do
-    @invalid_attrs %{limit: nil, name: nil}
+    @invalid_attrs %{total_limit: nil, remaining_limit: nil, status: nil, name: nil}
 
     test "list_activity_categories/0 returns all activity_categories" do
       activity_category = activity_category_fixture()
@@ -24,12 +24,14 @@ defmodule CollegeTracker.ExtracurricularActivitiesTest do
     end
 
     test "create_activity_category/1 with valid data creates a activity_category" do
-      valid_attrs = %{limit: 42, name: "some name"}
+      valid_attrs = %{total_limit: 42, remaining_limit: 42, status: :available, name: "some name"}
 
       assert {:ok, %ActivityCategory{} = activity_category} =
                ExtracurricularActivities.create_activity_category(valid_attrs)
 
-      assert activity_category.limit == 42
+      assert activity_category.total_limit == 42
+      assert activity_category.remaining_limit == 42
+      assert activity_category.status == :available
       assert activity_category.name == "some name"
     end
 
@@ -40,12 +42,20 @@ defmodule CollegeTracker.ExtracurricularActivitiesTest do
 
     test "update_activity_category/2 with valid data updates the activity_category" do
       activity_category = activity_category_fixture()
-      update_attrs = %{limit: 43, name: "some updated name"}
+
+      update_attrs = %{
+        total_limit: 43,
+        remaining_limit: 43,
+        status: :available,
+        name: "some updated name"
+      }
 
       assert {:ok, %ActivityCategory{} = activity_category} =
                ExtracurricularActivities.update_activity_category(activity_category, update_attrs)
 
-      assert activity_category.limit == 43
+      assert activity_category.total_limit == 43
+      assert activity_category.remaining_limit == 43
+      assert activity_category.status == :available
       assert activity_category.name == "some updated name"
     end
 

--- a/test/college_tracker/extracurricular_activities_test.exs
+++ b/test/college_tracker/extracurricular_activities_test.exs
@@ -184,4 +184,114 @@ defmodule CollegeTracker.ExtracurricularActivitiesTest do
       assert %Ecto.Changeset{} = ExtracurricularActivities.change_activity_type(activity_type)
     end
   end
+
+  describe "activities" do
+    alias CollegeTracker.ExtracurricularActivities.Activity
+
+    import CollegeTracker.ExtracurricularActivitiesFixtures
+
+    @invalid_attrs %{
+      certificate: nil,
+      description: nil,
+      end_date: nil,
+      hours: nil,
+      name: nil,
+      start_date: nil,
+      status: nil,
+      submission_date: nil
+    }
+
+    test "list_activities/0 returns all activities" do
+      activity = activity_fixture()
+      assert ExtracurricularActivities.list_activities() == [activity]
+    end
+
+    test "get_activity!/1 returns the activity with given id" do
+      activity = activity_fixture()
+      assert ExtracurricularActivities.get_activity!(activity.id) == activity
+    end
+
+    test "create_activity/1 with valid data creates a activity" do
+      %{id: activity_type_id} = activity_type_fixture()
+
+      valid_attrs = %{
+        certificate: "some certificate",
+        description: "some description",
+        end_date: ~D[2023-06-15],
+        hours: 42,
+        name: "some name",
+        start_date: ~D[2023-06-15],
+        status: :draft,
+        submission_date: ~D[2023-06-15],
+        activity_type_id: activity_type_id
+      }
+
+      assert {:ok, %Activity{} = activity} =
+               ExtracurricularActivities.create_activity(valid_attrs)
+
+      assert activity.certificate == "some certificate"
+      assert activity.description == "some description"
+      assert activity.end_date == ~D[2023-06-15]
+      assert activity.hours == 42
+      assert activity.name == "some name"
+      assert activity.start_date == ~D[2023-06-15]
+      assert activity.status == :draft
+      assert activity.submission_date == ~D[2023-06-15]
+    end
+
+    test "create_activity/1 with invalid data returns error changeset" do
+      assert {:error, %Ecto.Changeset{}} =
+               ExtracurricularActivities.create_activity(@invalid_attrs)
+    end
+
+    test "update_activity/2 with valid data updates the activity" do
+      activity = activity_fixture()
+
+      update_attrs = %{
+        certificate: "some updated certificate",
+        description: "some updated description",
+        end_date: ~D[2023-06-16],
+        hours: 43,
+        name: "some updated name",
+        start_date: ~D[2023-06-16],
+        status: :submitted,
+        submission_date: ~D[2023-06-16]
+      }
+
+      assert {:ok, %Activity{} = activity} =
+               ExtracurricularActivities.update_activity(activity, update_attrs)
+
+      assert activity.certificate == "some updated certificate"
+      assert activity.description == "some updated description"
+      assert activity.end_date == ~D[2023-06-16]
+      assert activity.hours == 43
+      assert activity.name == "some updated name"
+      assert activity.start_date == ~D[2023-06-16]
+      assert activity.status == :submitted
+      assert activity.submission_date == ~D[2023-06-16]
+    end
+
+    test "update_activity/2 with invalid data returns error changeset" do
+      activity = activity_fixture()
+
+      assert {:error, %Ecto.Changeset{}} =
+               ExtracurricularActivities.update_activity(activity, @invalid_attrs)
+
+      assert activity == ExtracurricularActivities.get_activity!(activity.id)
+    end
+
+    test "delete_activity/1 deletes the activity" do
+      activity = activity_fixture()
+      assert {:ok, %Activity{}} = ExtracurricularActivities.delete_activity(activity)
+
+      assert_raise Ecto.NoResultsError, fn ->
+        ExtracurricularActivities.get_activity!(activity.id)
+      end
+    end
+
+    test "change_activity/1 returns a activity changeset" do
+      activity = activity_fixture()
+      assert %Ecto.Changeset{} = ExtracurricularActivities.change_activity(activity)
+    end
+  end
 end

--- a/test/college_tracker/extracurricular_activities_test.exs
+++ b/test/college_tracker/extracurricular_activities_test.exs
@@ -6,6 +6,7 @@ defmodule CollegeTracker.ExtracurricularActivitiesTest do
 
   alias CollegeTracker.ExtracurricularActivities
   alias CollegeTracker.ExtracurricularActivities.ActivityCategory
+  alias CollegeTracker.ExtracurricularActivities.ActivityType
 
   describe "activity_categories" do
     @invalid_attrs %{limit: nil, name: nil}
@@ -77,6 +78,100 @@ defmodule CollegeTracker.ExtracurricularActivitiesTest do
 
       assert %Ecto.Changeset{} =
                ExtracurricularActivities.change_activity_category(activity_category)
+    end
+  end
+
+  describe "activity_types" do
+    @invalid_attrs %{
+      name: nil,
+      status: nil,
+      total_limit: nil,
+      individual_limit: nil,
+      remaining_limit: nil
+    }
+
+    test "list_activity_types/0 returns all activity_types" do
+      activity_type = activity_type_fixture()
+      assert ExtracurricularActivities.list_activity_types() == [activity_type]
+    end
+
+    test "get_activity_type!/1 returns the activity_type with given id" do
+      activity_type = activity_type_fixture()
+      assert ExtracurricularActivities.get_activity_type!(activity_type.id) == activity_type
+    end
+
+    test "create_activity_type/1 with valid data creates a activity_type" do
+      %{id: activity_category_id} = activity_category_fixture()
+
+      valid_attrs = %{
+        name: "some name",
+        status: :unqualified,
+        total_limit: 42,
+        individual_limit: 42,
+        remaining_limit: 42,
+        activity_category_id: activity_category_id
+      }
+
+      assert {:ok, %ActivityType{} = activity_type} =
+               ExtracurricularActivities.create_activity_type(valid_attrs)
+
+      assert activity_type.name == "some name"
+      assert activity_type.status == :unqualified
+      assert activity_type.total_limit == 42
+      assert activity_type.individual_limit == 42
+      assert activity_type.remaining_limit == 42
+      assert activity_type.activity_category_id == activity_category_id
+    end
+
+    test "create_activity_type/1 with invalid data returns error changeset" do
+      assert {:error, %Ecto.Changeset{}} =
+               ExtracurricularActivities.create_activity_type(@invalid_attrs)
+    end
+
+    test "update_activity_type/2 with valid data updates the activity_type" do
+      activity_type = activity_type_fixture()
+
+      update_attrs = %{
+        name: "some updated name",
+        status: :available,
+        total_limit: 43,
+        individual_limit: 43,
+        remaining_limit: 43
+      }
+
+      assert {:ok, %ActivityType{} = activity_type} =
+               ExtracurricularActivities.update_activity_type(activity_type, update_attrs)
+
+      assert activity_type.name == "some updated name"
+      assert activity_type.status == :available
+      assert activity_type.total_limit == 43
+      assert activity_type.individual_limit == 43
+      assert activity_type.remaining_limit == 43
+    end
+
+    test "update_activity_type/2 with invalid data returns error changeset" do
+      activity_type = activity_type_fixture()
+
+      assert {:error, %Ecto.Changeset{}} =
+               ExtracurricularActivities.update_activity_type(activity_type, @invalid_attrs)
+
+      assert activity_type == ExtracurricularActivities.get_activity_type!(activity_type.id)
+    end
+
+    test "delete_activity_type/1 deletes the activity_type" do
+      activity_type = activity_type_fixture()
+
+      assert {:ok, %ActivityType{}} =
+               ExtracurricularActivities.delete_activity_type(activity_type)
+
+      assert_raise Ecto.NoResultsError, fn ->
+        ExtracurricularActivities.get_activity_type!(activity_type.id)
+      end
+    end
+
+    test "change_activity_type/1 returns a activity_type changeset" do
+      activity_type = activity_type_fixture()
+      assert %Ecto.Changeset{} = ExtracurricularActivities.change_activity_type(activity_type)
     end
   end
 end

--- a/test/college_tracker_web/live/activity_category_live_test.exs
+++ b/test/college_tracker_web/live/activity_category_live_test.exs
@@ -1,0 +1,128 @@
+defmodule CollegeTrackerWeb.ActivityCategoryLiveTest do
+  @moduledoc false
+  use CollegeTrackerWeb.ConnCase
+
+  import Phoenix.LiveViewTest
+  import CollegeTracker.ExtracurricularActivitiesFixtures
+
+  @create_attrs %{limit: 42, name: "some name"}
+  @update_attrs %{limit: 43, name: "some updated name"}
+  @invalid_attrs %{limit: nil, name: nil}
+
+  defp create_activity_category(_) do
+    activity_category = activity_category_fixture()
+    %{activity_category: activity_category}
+  end
+
+  describe "Index" do
+    setup [:create_activity_category]
+
+    test "lists all activity_categories", %{conn: conn, activity_category: activity_category} do
+      {:ok, _index_live, html} = live(conn, ~p"/activity_categories")
+
+      assert html =~ "Listing Activity categories"
+      assert html =~ activity_category.name
+    end
+
+    test "saves new activity_category", %{conn: conn} do
+      {:ok, index_live, _html} = live(conn, ~p"/activity_categories")
+
+      assert index_live |> element("a", "New Activity category") |> render_click() =~
+               "New Activity category"
+
+      assert_patch(index_live, ~p"/activity_categories/new")
+
+      assert index_live
+             |> form("#activity_category-form", activity_category: @invalid_attrs)
+             |> render_change() =~ "can&#39;t be blank"
+
+      assert index_live
+             |> form("#activity_category-form", activity_category: @create_attrs)
+             |> render_submit()
+
+      assert_patch(index_live, ~p"/activity_categories")
+
+      html = render(index_live)
+      assert html =~ "Activity category created successfully"
+      assert html =~ "some name"
+    end
+
+    test "updates activity_category in listing", %{
+      conn: conn,
+      activity_category: activity_category
+    } do
+      {:ok, index_live, _html} = live(conn, ~p"/activity_categories")
+
+      assert index_live
+             |> element("#activity_categories-#{activity_category.id} a", "Edit")
+             |> render_click() =~
+               "Edit Activity category"
+
+      assert_patch(index_live, ~p"/activity_categories/#{activity_category}/edit")
+
+      assert index_live
+             |> form("#activity_category-form", activity_category: @invalid_attrs)
+             |> render_change() =~ "can&#39;t be blank"
+
+      assert index_live
+             |> form("#activity_category-form", activity_category: @update_attrs)
+             |> render_submit()
+
+      assert_patch(index_live, ~p"/activity_categories")
+
+      html = render(index_live)
+      assert html =~ "Activity category updated successfully"
+      assert html =~ "some updated name"
+    end
+
+    test "deletes activity_category in listing", %{
+      conn: conn,
+      activity_category: activity_category
+    } do
+      {:ok, index_live, _html} = live(conn, ~p"/activity_categories")
+
+      assert index_live
+             |> element("#activity_categories-#{activity_category.id} a", "Delete")
+             |> render_click()
+
+      refute has_element?(index_live, "#activity_categories-#{activity_category.id}")
+    end
+  end
+
+  describe "Show" do
+    setup [:create_activity_category]
+
+    test "displays activity_category", %{conn: conn, activity_category: activity_category} do
+      {:ok, _show_live, html} = live(conn, ~p"/activity_categories/#{activity_category}")
+
+      assert html =~ "Show Activity category"
+      assert html =~ activity_category.name
+    end
+
+    test "updates activity_category within modal", %{
+      conn: conn,
+      activity_category: activity_category
+    } do
+      {:ok, show_live, _html} = live(conn, ~p"/activity_categories/#{activity_category}")
+
+      assert show_live |> element("a", "Edit") |> render_click() =~
+               "Edit Activity category"
+
+      assert_patch(show_live, ~p"/activity_categories/#{activity_category}/show/edit")
+
+      assert show_live
+             |> form("#activity_category-form", activity_category: @invalid_attrs)
+             |> render_change() =~ "can&#39;t be blank"
+
+      assert show_live
+             |> form("#activity_category-form", activity_category: @update_attrs)
+             |> render_submit()
+
+      assert_patch(show_live, ~p"/activity_categories/#{activity_category}")
+
+      html = render(show_live)
+      assert html =~ "Activity category updated successfully"
+      assert html =~ "some updated name"
+    end
+  end
+end

--- a/test/college_tracker_web/live/activity_category_live_test.exs
+++ b/test/college_tracker_web/live/activity_category_live_test.exs
@@ -5,9 +5,16 @@ defmodule CollegeTrackerWeb.ActivityCategoryLiveTest do
   import Phoenix.LiveViewTest
   import CollegeTracker.ExtracurricularActivitiesFixtures
 
-  @create_attrs %{limit: 42, name: "some name"}
-  @update_attrs %{limit: 43, name: "some updated name"}
-  @invalid_attrs %{limit: nil, name: nil}
+  @create_attrs %{name: "some name", total_limit: 42, remaining_limit: 30, status: :available}
+
+  @update_attrs %{
+    name: "some updated name",
+    total_limit: 43,
+    remaining_limit: 31,
+    status: :complete
+  }
+
+  @invalid_attrs %{name: nil, total_limit: nil, remaining_limit: nil, status: :complete}
 
   defp create_activity_category(_) do
     activity_category = activity_category_fixture()

--- a/test/college_tracker_web/live/activity_live_test.exs
+++ b/test/college_tracker_web/live/activity_live_test.exs
@@ -1,0 +1,147 @@
+defmodule CollegeTrackerWeb.ActivityLiveTest do
+  @moduledoc false
+  use CollegeTrackerWeb.ConnCase
+
+  import Phoenix.LiveViewTest
+  import CollegeTracker.ExtracurricularActivitiesFixtures
+
+  alias CollegeTracker.ExtracurricularActivities.ActivityType
+  alias CollegeTracker.Repo
+
+  @create_attrs %{
+    certificate: "some certificate",
+    description: "some description",
+    end_date: "2023-06-15",
+    hours: 42,
+    name: "some name",
+    start_date: "2023-06-15",
+    status: :draft,
+    submission_date: "2023-06-15"
+  }
+  @update_attrs %{
+    certificate: "some updated certificate",
+    description: "some updated description",
+    end_date: "2023-06-16",
+    hours: 43,
+    name: "some updated name",
+    start_date: "2023-06-16",
+    status: :submitted,
+    submission_date: "2023-06-16"
+  }
+  @invalid_attrs %{
+    certificate: nil,
+    description: nil,
+    end_date: nil,
+    hours: nil,
+    name: nil,
+    start_date: nil,
+    status: nil,
+    submission_date: nil
+  }
+
+  defp create_activity(_) do
+    activity = activity_fixture()
+    %{activity: activity}
+  end
+
+  describe "Index" do
+    setup [:create_activity]
+
+    test "lists all activities", %{conn: conn, activity: activity} do
+      {:ok, _index_live, html} = live(conn, ~p"/activities")
+
+      assert html =~ "Listing Activities"
+      assert html =~ activity.certificate
+    end
+
+    test "saves new activity", %{conn: conn} do
+      {:ok, index_live, _html} = live(conn, ~p"/activities")
+
+      assert index_live |> element("a", "New Activity") |> render_click() =~
+               "New Activity"
+
+      assert_patch(index_live, ~p"/activities/new")
+
+      assert index_live
+             |> form("#activity-form", activity: @invalid_attrs)
+             |> render_change() =~ "can&#39;t be blank"
+
+      %{id: activity_type_id} = Repo.one(ActivityType)
+      create_attrs = Map.merge(@create_attrs, %{activity_type_id: activity_type_id})
+
+      assert index_live
+             |> form("#activity-form", activity: create_attrs)
+             |> render_submit()
+
+      assert_patch(index_live, ~p"/activities")
+
+      html = render(index_live)
+      assert html =~ "Activity created successfully"
+      assert html =~ "some certificate"
+    end
+
+    test "updates activity in listing", %{conn: conn, activity: activity} do
+      {:ok, index_live, _html} = live(conn, ~p"/activities")
+
+      assert index_live |> element("#activities-#{activity.id} a", "Edit") |> render_click() =~
+               "Edit Activity"
+
+      assert_patch(index_live, ~p"/activities/#{activity}/edit")
+
+      assert index_live
+             |> form("#activity-form", activity: @invalid_attrs)
+             |> render_change() =~ "can&#39;t be blank"
+
+      assert index_live
+             |> form("#activity-form", activity: @update_attrs)
+             |> render_submit()
+
+      assert_patch(index_live, ~p"/activities")
+
+      html = render(index_live)
+      assert html =~ "Activity updated successfully"
+      assert html =~ "some updated certificate"
+    end
+
+    test "deletes activity in listing", %{conn: conn, activity: activity} do
+      {:ok, index_live, _html} = live(conn, ~p"/activities")
+
+      assert index_live |> element("#activities-#{activity.id} a", "Delete") |> render_click()
+      refute has_element?(index_live, "#activities-#{activity.id}")
+    end
+  end
+
+  describe "Show" do
+    setup [:create_activity]
+
+    test "displays activity", %{conn: conn, activity: activity} do
+      {:ok, _show_live, html} = live(conn, ~p"/activities/#{activity}")
+
+      assert html =~ "Show Activity"
+      assert html =~ activity.certificate
+    end
+
+    test "updates activity within modal", %{conn: conn, activity: activity} do
+      {:ok, show_live, _html} = live(conn, ~p"/activities/#{activity}")
+
+      assert show_live |> element("a", "Edit") |> render_click() =~
+               "Edit Activity"
+
+      assert_patch(show_live, ~p"/activities/#{activity}/show/edit")
+
+      assert show_live
+             |> form("#activity-form", activity: @invalid_attrs)
+             |> render_change() =~ "can&#39;t be blank"
+
+      assert show_live
+             |> form("#activity-form", activity: @update_attrs)
+             |> render_submit()
+
+      assert_patch(show_live, ~p"/activities/#{activity}")
+
+      html = render(show_live)
+      assert html =~ "Activity updated successfully"
+      assert html =~ "some updated certificate"
+    end
+  end
+end

--- a/test/college_tracker_web/live/activity_type_live_test.exs
+++ b/test/college_tracker_web/live/activity_type_live_test.exs
@@ -1,0 +1,143 @@
+defmodule CollegeTrackerWeb.ActivityTypeLiveTest do
+  @moduledoc false
+  use CollegeTrackerWeb.ConnCase
+
+  import Phoenix.LiveViewTest
+  import CollegeTracker.ExtracurricularActivitiesFixtures
+
+  alias CollegeTracker.ExtracurricularActivities.ActivityCategory
+  alias CollegeTracker.Repo
+
+  @create_attrs %{
+    name: "some name",
+    status: :unqualified,
+    total_limit: 42,
+    individual_limit: 42,
+    remaining_limit: 42
+  }
+  @update_attrs %{
+    name: "some updated name",
+    status: :available,
+    total_limit: 43,
+    individual_limit: 43,
+    remaining_limit: 43
+  }
+  @invalid_attrs %{
+    name: nil,
+    status: nil,
+    total_limit: nil,
+    individual_limit: nil,
+    remaining_limit: nil
+  }
+
+  defp create_activity_type(_) do
+    activity_type = activity_type_fixture()
+    %{activity_type: activity_type}
+  end
+
+  describe "Index" do
+    setup [:create_activity_type]
+
+    test "lists all activity_types", %{conn: conn, activity_type: activity_type} do
+      {:ok, _index_live, html} = live(conn, ~p"/activity_types")
+
+      assert html =~ "Listing Activity types"
+      assert html =~ activity_type.name
+    end
+
+    test "saves new activity_type", %{conn: conn} do
+      {:ok, index_live, _html} = live(conn, ~p"/activity_types")
+
+      assert index_live |> element("a", "New Activity type") |> render_click() =~
+               "New Activity type"
+
+      assert_patch(index_live, ~p"/activity_types/new")
+
+      assert index_live
+             |> form("#activity_type-form", activity_type: @invalid_attrs)
+             |> render_change() =~ "can&#39;t be blank"
+
+      %{id: activity_category_id} = Repo.one(ActivityCategory)
+      create_attrs = Map.merge(@create_attrs, %{activity_category_id: activity_category_id})
+
+      assert index_live
+             |> form("#activity_type-form", activity_type: create_attrs)
+             |> render_submit()
+
+      assert_patch(index_live, ~p"/activity_types")
+
+      html = render(index_live)
+      assert html =~ "Activity type created successfully"
+      assert html =~ "some name"
+    end
+
+    test "updates activity_type in listing", %{conn: conn, activity_type: activity_type} do
+      {:ok, index_live, _html} = live(conn, ~p"/activity_types")
+
+      assert index_live
+             |> element("#activity_types-#{activity_type.id} a", "Edit")
+             |> render_click() =~
+               "Edit Activity type"
+
+      assert_patch(index_live, ~p"/activity_types/#{activity_type}/edit")
+
+      assert index_live
+             |> form("#activity_type-form", activity_type: @invalid_attrs)
+             |> render_change() =~ "can&#39;t be blank"
+
+      assert index_live
+             |> form("#activity_type-form", activity_type: @update_attrs)
+             |> render_submit()
+
+      assert_patch(index_live, ~p"/activity_types")
+
+      html = render(index_live)
+      assert html =~ "Activity type updated successfully"
+      assert html =~ "some updated name"
+    end
+
+    test "deletes activity_type in listing", %{conn: conn, activity_type: activity_type} do
+      {:ok, index_live, _html} = live(conn, ~p"/activity_types")
+
+      assert index_live
+             |> element("#activity_types-#{activity_type.id} a", "Delete")
+             |> render_click()
+
+      refute has_element?(index_live, "#activity_types-#{activity_type.id}")
+    end
+  end
+
+  describe "Show" do
+    setup [:create_activity_type]
+
+    test "displays activity_type", %{conn: conn, activity_type: activity_type} do
+      {:ok, _show_live, html} = live(conn, ~p"/activity_types/#{activity_type}")
+
+      assert html =~ "Show Activity type"
+      assert html =~ activity_type.name
+    end
+
+    test "updates activity_type within modal", %{conn: conn, activity_type: activity_type} do
+      {:ok, show_live, _html} = live(conn, ~p"/activity_types/#{activity_type}")
+
+      assert show_live |> element("a", "Edit") |> render_click() =~
+               "Edit Activity type"
+
+      assert_patch(show_live, ~p"/activity_types/#{activity_type}/show/edit")
+
+      assert show_live
+             |> form("#activity_type-form", activity_type: @invalid_attrs)
+             |> render_change() =~ "can&#39;t be blank"
+
+      assert show_live
+             |> form("#activity_type-form", activity_type: @update_attrs)
+             |> render_submit()
+
+      assert_patch(show_live, ~p"/activity_types/#{activity_type}")
+
+      html = render(show_live)
+      assert html =~ "Activity type updated successfully"
+      assert html =~ "some updated name"
+    end
+  end
+end

--- a/test/support/fixtures/extracurricular_activities_fixtures.ex
+++ b/test/support/fixtures/extracurricular_activities_fixtures.ex
@@ -11,7 +11,9 @@ defmodule CollegeTracker.ExtracurricularActivitiesFixtures do
     {:ok, activity_category} =
       attrs
       |> Enum.into(%{
-        limit: 42,
+        total_limit: 42,
+        remaining_limit: 42,
+        status: :available,
         name: "some name"
       })
       |> CollegeTracker.ExtracurricularActivities.create_activity_category()

--- a/test/support/fixtures/extracurricular_activities_fixtures.ex
+++ b/test/support/fixtures/extracurricular_activities_fixtures.ex
@@ -41,4 +41,28 @@ defmodule CollegeTracker.ExtracurricularActivitiesFixtures do
 
     activity_type
   end
+
+  @doc """
+  Generate a activity.
+  """
+  def activity_fixture(attrs \\ %{}) do
+    %{id: activity_type_id} = activity_type_fixture()
+
+    {:ok, activity} =
+      attrs
+      |> Enum.into(%{
+        certificate: "some certificate",
+        description: "some description",
+        end_date: ~D[2023-06-15],
+        hours: 42,
+        name: "some name",
+        start_date: ~D[2023-06-15],
+        status: :draft,
+        submission_date: ~D[2023-06-15],
+        activity_type_id: activity_type_id
+      })
+      |> CollegeTracker.ExtracurricularActivities.create_activity()
+
+    activity
+  end
 end

--- a/test/support/fixtures/extracurricular_activities_fixtures.ex
+++ b/test/support/fixtures/extracurricular_activities_fixtures.ex
@@ -18,4 +18,25 @@ defmodule CollegeTracker.ExtracurricularActivitiesFixtures do
 
     activity_category
   end
+
+  @doc """
+  Generate a activity_type.
+  """
+  def activity_type_fixture(attrs \\ %{}) do
+    %{id: activity_category_id} = activity_category_fixture()
+
+    {:ok, activity_type} =
+      attrs
+      |> Enum.into(%{
+        name: "some name",
+        status: :unqualified,
+        total_limit: 42,
+        individual_limit: 42,
+        remaining_limit: 42,
+        activity_category_id: activity_category_id
+      })
+      |> CollegeTracker.ExtracurricularActivities.create_activity_type()
+
+    activity_type
+  end
 end

--- a/test/support/fixtures/extracurricular_activities_fixtures.ex
+++ b/test/support/fixtures/extracurricular_activities_fixtures.ex
@@ -1,0 +1,21 @@
+defmodule CollegeTracker.ExtracurricularActivitiesFixtures do
+  @moduledoc """
+  This module defines test helpers for creating
+  entities via the `CollegeTracker.ExtracurricularActivities` context.
+  """
+
+  @doc """
+  Generate a activity_category.
+  """
+  def activity_category_fixture(attrs \\ %{}) do
+    {:ok, activity_category} =
+      attrs
+      |> Enum.into(%{
+        limit: 42,
+        name: "some name"
+      })
+      |> CollegeTracker.ExtracurricularActivities.create_activity_category()
+
+    activity_category
+  end
+end


### PR DESCRIPTION
# Purpose

This PR introduces three new Elixir/Ecto models: `ActivityCategory`,
`ActivityType`, and `Activity`. The purpose is to allow our application to
manage extracurricular activities for a college student. These models will enable 
us to categorize activities, set different types of activities under each category,
and create individual activities related to specific types.

## Approach

The problem is addressed by using Ecto schemas in Elixir to create corresponding
models for `ActivityCategory`, `ActivityType`, and `Activity`. We define
necessary fields for each schema and the relationships between them.
`ActivityCategory` and `ActivityType` are related through a one-to-many
association, while `ActivityType` and `Activity` are also related via a
one-to-many association.

## Database migrations

This PR introduces database migrations that create tables for each model with
the necessary fields and constraints.

- [x] I have confirmed that the Ecto Schema and database migrations have
  equivalent restrictions.
  - [x] default values are the same: `status` fields in `ActivityType` and
    `Activity` models both have default values in the schema and migration.
  - [x] whether null/nil values restrictions are the same: the required fields
    in the schema are enforced to be not null in the migrations.

- [ ] Where necessary, I have added tests of the migration as documented
  [here](https://docs.turn.systems/testing_guideline.html#testing-database-migrations)
  - [ ] N/A, as no complex operations are performed in the migrations, testing
    of the migrations is not necessary.

- [x] I have checked whether any of the migrations will need to be run manually
  - [x] No manual migrations are needed.
  - [x] N/A, no raw SQL is included within the migration file.
