### PR TITLE
validate fields in `Activity`

### DIFF
--- a/test/college_tracker/extracurricular_activities/activity_test.exs
+++ b/test/college_tracker/extracurricular_activities/activity_test.exs
@@ -1,0 +1,49 @@
+defmodule CollegeTracker.ExtracurricularActivities.ActivityTest do
+  @moduledoc false
+  use CollegeTracker.DataCase, async: true
+
+  import CollegeTracker.ExtracurricularActivitiesFixtures
+
+  alias CollegeTracker.ExtracurricularActivities.Activity
+
+  describe "changeset/2" do
+    setup do
+      activity_type = activity_type_fixture(%{individual_limit: 5})
+      %{activity_type: activity_type}
+    end
+
+    test "validates that the end date is not before the start date", %{
+      activity_type: activity_type
+    } do
+      attrs = %{
+        "name" => "My Activity",
+        "status" => :draft,
+        "hours" => 5,
+        "activity_type_id" => activity_type.id,
+        "start_date" => ~D[2023-07-01],
+        "end_date" => ~D[2023-06-01]
+      }
+
+      assert %Ecto.Changeset{valid?: false, errors: errors} =
+               Activity.changeset(%Activity{}, attrs)
+
+      assert {:start_date, _} = List.keyfind(errors, :start_date, 0)
+    end
+
+    test "validates that the hours are not higher than the individual limit", %{
+      activity_type: activity_type
+    } do
+      attrs = %{
+        "name" => "My Activity",
+        "status" => :draft,
+        "hours" => 6,
+        "activity_type_id" => activity_type.id
+      }
+
+      assert %Ecto.Changeset{valid?: false, errors: errors} =
+               Activity.changeset(%Activity{}, attrs)
+
+      assert {:hours, _} = List.keyfind(errors, :hours, 0)
+    end
+  end
+end

--- a/test/college_tracker/extracurricular_activities_test.exs
+++ b/test/college_tracker/extracurricular_activities_test.exs
@@ -5,6 +5,7 @@ defmodule CollegeTracker.ExtracurricularActivitiesTest do
   import CollegeTracker.ExtracurricularActivitiesFixtures
 
   alias CollegeTracker.ExtracurricularActivities
+  alias CollegeTracker.ExtracurricularActivities.Activity
   alias CollegeTracker.ExtracurricularActivities.ActivityCategory
   alias CollegeTracker.ExtracurricularActivities.ActivityType
 
@@ -186,10 +187,6 @@ defmodule CollegeTracker.ExtracurricularActivitiesTest do
   end
 
   describe "activities" do
-    alias CollegeTracker.ExtracurricularActivities.Activity
-
-    import CollegeTracker.ExtracurricularActivitiesFixtures
-
     @invalid_attrs %{
       certificate: nil,
       description: nil,
@@ -251,7 +248,7 @@ defmodule CollegeTracker.ExtracurricularActivitiesTest do
         certificate: "some updated certificate",
         description: "some updated description",
         end_date: ~D[2023-06-16],
-        hours: 43,
+        hours: 40,
         name: "some updated name",
         start_date: ~D[2023-06-16],
         status: :submitted,
@@ -264,7 +261,7 @@ defmodule CollegeTracker.ExtracurricularActivitiesTest do
       assert activity.certificate == "some updated certificate"
       assert activity.description == "some updated description"
       assert activity.end_date == ~D[2023-06-16]
-      assert activity.hours == 43
+      assert activity.hours == 40
       assert activity.name == "some updated name"
       assert activity.start_date == ~D[2023-06-16]
       assert activity.status == :submitted

--- a/test/college_tracker_web/live/activity_live_test.exs
+++ b/test/college_tracker_web/live/activity_live_test.exs
@@ -22,7 +22,7 @@ defmodule CollegeTrackerWeb.ActivityLiveTest do
     certificate: "some updated certificate",
     description: "some updated description",
     end_date: "2023-06-16",
-    hours: 43,
+    hours: 40,
     name: "some updated name",
     start_date: "2023-06-16",
     status: :submitted,


### PR DESCRIPTION
## Purpose

The purpose of this PR is to introduce additional data validation to the `Activity` model. We are adding rules to ensure that the activity's `end_date` is not earlier than its `start_date` and that the hours dedicated to an activity do not exceed the `individual_limit` set on its associated `ActivityType`. 

## Approach

The validation is achieved by introducing two new private functions, `validate_date_range/3` and `validate_hours_limit/3`, within our Ecto changeset in the `Activity` model.

The `validate_date_range/3` function checks whether the start date of an activity is before the end date. If the start date is after the end date, an error message is attached to the changeset.

The `validate_hours_limit/3` function verifies that the hours dedicated to an activity are not greater than the `individual_limit` of the associated `ActivityType`. If the hours exceed the limit, an error message is added to the changeset.

These functions are invoked in the `changeset/2` function, which is used when creating or updating activities. This addition helps maintain data integrity by ensuring that we only persist valid activities to our database.

## Tests

A new set of tests have been added under `test/college_tracker/extracurricular_activities/activity_test.exs` to ensure that our new validation rules are working correctly.

We have test cases that attempt to create activities with invalid data (start date being after the end date and hours exceeding the associated activity type's limit). In each case, we expect that our changeset is marked as invalid, and an appropriate error message is attached to the respective field.
